### PR TITLE
Import SimpleBar styling via component file

### DIFF
--- a/addon/components/simple-bar.js
+++ b/addon/components/simple-bar.js
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import SimpleBarCore from 'simplebar-core';
+import 'simplebar-core/dist/simplebar.css';
 
 export default class SimpleBarComponent extends Component {
   @tracked

--- a/index.js
+++ b/index.js
@@ -2,9 +2,4 @@
 
 module.exports = {
   name: require('./package').name,
-
-  included(app) {
-    this._super.included.apply(this, arguments);
-    app.import('node_modules/simplebar-core/dist/simplebar.css');
-  },
 };


### PR DESCRIPTION
Using `ember-simplebar` in a pnpm monorepo doesn't work, because the addon assumes SimpleBar's css file is located at `node_modules/simplebar-core/dist/simplebar.css`. This is not something we can assume if we want the addon to work under different package managers.